### PR TITLE
Switch to Snyk

### DIFF
--- a/dangerfiles/greenkeeper.ts
+++ b/dangerfiles/greenkeeper.ts
@@ -16,9 +16,9 @@ export default async () => {
   const commits = danger.github.commits;
   const { user } = pr;
 
-  if (user.id !== 23040076 || user.type !== 'Bot') {
-    if (user.login === 'greenkeeper[bot]') {
-      warn('Greenkeeper bot changed its ID');
+  if (user.id !== 19733683 || user.type !== 'Bot') {
+    if (user.login === 'snyk-bot') {
+      warn('Snyk bot changed its ID');
     }
     return;
   }

--- a/dangerfiles/greenkeeper.ts
+++ b/dangerfiles/greenkeeper.ts
@@ -16,7 +16,7 @@ export default async () => {
   const commits = danger.github.commits;
   const { user } = pr;
 
-  if (user.id !== 19733683 || user.type !== 'Bot') {
+  if (user.id !== 19733683 || user.type !== 'User') {
     if (user.login === 'snyk-bot') {
       warn('Snyk bot changed its ID');
     }


### PR DESCRIPTION
Greenkeeper has been incorporated to Synk so the Peril bot which approves and merges dependency PRs no longer functions. This PR attempts to get the Peril bot to act on Synk PRs.